### PR TITLE
v0.4.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+0.4.0
+==================
+
+* No longer use django cache
+* Renamed `DjConfigLocMemMiddleware` to `DjConfigMiddleware`
+* `DjConfigMiddleware` is required
+
 0.3.2
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ and stored in an in-memory cache for later access.
 
 1. `pip install django-djconfig`
 2. Add `djconfig` to `INSTALLED_APPS`
-3. Run `python manage.py migrate`
-4. [Set a cache backend](https://github.com/nitely/django-djconfig#backends)
-5. (Optional) Add `djconfig.middleware.DjConfigLocMemMiddleware` to `MIDDLEWARE_CLASSES` if you are using django `LocMemCache`
-6. (Optional) Add `djconfig.context_processors.config` to `TEMPLATE_CONTEXT_PROCESSORS` to access the `config` within your templates
+3. Add `djconfig.middleware.DjConfigLocMemMiddleware` to `MIDDLEWARE_CLASSES`
+4. Add `djconfig.context_processors.config` to `TEMPLATE_CONTEXT_PROCESSORS`
+5. Run `python manage.py migrate`
 
 ## Usage
 
@@ -74,9 +73,6 @@ if config.my_first_key:
 
 Accessing the config within templates:
 
-> Requires setting `djconfig.context_processors.config` or
-> manually passing the `config` object to your RequestContext
-
 ```python
 # template.html
 
@@ -109,58 +105,15 @@ def config_view(request):
     return render(request, 'app/configuration.html', {'form': form, })
 ```
 
-## Backends
-
-An *in-memory* cache is required.
-
-```python
-# settings.py
-
-# ...
-
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    }
-}
-```
-
-To use other backend than the default, add `DJC_BACKEND = 'my_backend'` in your *settings.py* file.
-
-Supported backends:
-* `LocMemCache`
-* `Memcached`
-* `Redis` (requires [django-redis-cache](https://github.com/sebleier/django-redis-cache))
-* Any other in-memory cache.
-
-> **Note**: When using `LocMemCache` you should add `djconfig.middleware.DjConfigLocMemMiddleware` to `MIDDLEWARE_CLASSES`.
->
-> This will make cross-process caching work by reloading the cache on every request, if it was updated.
-
 ## Supported form fields
 
-The following form fields were tested: `BooleanField`, `CharField`, `EmailField`, `FloatField`, `IntegerField`, `URLField`.
+The following form fields were tested: `BooleanField`, `CharField`,
+`EmailField`, `FloatField`, `IntegerField`, `URLField`.
 
-Fields that return complex objects are not supported. Basically any object that can be store in a data base is supported, except for DateField which is not supported at this time (sorry).
+Fields that return complex objects are not supported.
+Basically any object that can be store in a data base is supported,
+except for DateField which is not supported at this time (sorry).
 
-## Testing
-
-Add `LOCATION` to `CACHES` so you can call `cache.clear()` to clear all the caches but the DjConfig one.
-
-Usage:
-```python
-CACHES = {
-    'default': {
-        # ...
-    },
-    'djconfig': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'test-djconfig',
-    },
-}
-
-DJC_BACKEND = 'djconfig'
-```
 
 ## Testing helpers
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and stored in an in-memory cache for later access.
 
 1. `pip install django-djconfig`
 2. Add `djconfig` to `INSTALLED_APPS`
-3. Add `djconfig.middleware.DjConfigLocMemMiddleware` to `MIDDLEWARE_CLASSES`
+3. Add `djconfig.middleware.DjConfigMiddleware` to `MIDDLEWARE_CLASSES`
 4. Add `djconfig.context_processors.config` to `TEMPLATE_CONTEXT_PROCESSORS`
 5. Run `python manage.py migrate`
 

--- a/djconfig/__init__.py
+++ b/djconfig/__init__.py
@@ -5,5 +5,5 @@ from __future__ import unicode_literals
 from .conf import config
 from .registry import register
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 __all__ = ['config', 'register']

--- a/djconfig/middleware.py
+++ b/djconfig/middleware.py
@@ -5,10 +5,10 @@ from __future__ import unicode_literals
 from . import conf
 from . import models
 
-__all__ = ['DjConfigLocMemMiddleware', ]
+__all__ = ['DjConfigMiddleware', ]
 
 
-class DjConfigLocMemMiddleware(object):
+class DjConfigMiddleware(object):
     """
     Populates the cache using the database.
     """
@@ -25,3 +25,7 @@ class DjConfigLocMemMiddleware(object):
 
         if data.get('_updated_at') != conf.config._updated_at:
             conf.config._reload()
+
+
+# Backward compatibility
+DjConfigLocMemMiddleware = DjConfigMiddleware

--- a/djconfig/middleware.py
+++ b/djconfig/middleware.py
@@ -2,33 +2,22 @@
 
 from __future__ import unicode_literals
 
-from django.conf import settings as django_settings
-
 from . import conf
 from . import models
-from . import settings
 
 __all__ = ['DjConfigLocMemMiddleware', ]
 
 
 class DjConfigLocMemMiddleware(object):
     """
-    Populates the cache using the database
-    required by the LocalMem backend
+    Populates the cache using the database.
     """
     def process_request(self, request):
-        self.check_backend()
         self.reload()
-
-    def check_backend(self):
-        backend = django_settings.CACHES[settings.BACKEND]
-
-        if not backend['BACKEND'].endswith((".LocMemCache", ".TestingCache")):
-            raise ValueError("DjConfigLocMemMiddleware requires LocMemCache as cache")
 
     def reload(self):
         """
-        This reloads the cache *only* if the database has changed.
+        Reload the cache *only* if the database has changed.
         """
         data = dict(models.Config.objects
                     .filter(key='_updated_at')

--- a/djconfig/registry.py
+++ b/djconfig/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+from django.conf import settings as django_settings
 
 _registered_forms = set()
 
@@ -21,3 +22,11 @@ def register(form_class):
         "The form does not inherit from ConfigForm"
 
     _registered_forms.add(form_class)
+    _check_backend()
+
+
+def _check_backend():
+    if "djconfig.middleware.DjConfigLocMemMiddleware" not in django_settings.MIDDLEWARE_CLASSES and\
+                    "djconfig.middleware.DjConfigMiddleware" not in django_settings.MIDDLEWARE_CLASSES:
+        raise ValueError("djconfig.middleware.DjConfigMiddleware is required "
+                         "but it was not found in MIDDLEWARE_CLASSES")

--- a/djconfig/registry.py
+++ b/djconfig/registry.py
@@ -2,9 +2,6 @@
 
 from __future__ import unicode_literals
 
-from django.conf import settings as django_settings
-
-from .settings import BACKEND
 
 _registered_forms = set()
 
@@ -24,11 +21,3 @@ def register(form_class):
         "The form does not inherit from ConfigForm"
 
     _registered_forms.add(form_class)
-    _check_backend()
-
-
-def _check_backend():
-    if django_settings.CACHES[BACKEND]['BACKEND'].endswith(".LocMemCache") and \
-            "djconfig.middleware.DjConfigLocMemMiddleware" not in django_settings.MIDDLEWARE_CLASSES:
-        raise ValueError("LocMemCache requires DjConfigLocMemMiddleware "
-                         "but it was not found in MIDDLEWARE_CLASSES")

--- a/djconfig/settings.py
+++ b/djconfig/settings.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
-from django.conf import settings
-
-
-BACKEND = getattr(settings, 'DJC_BACKEND', 'default')
-PREFIX = getattr(settings, 'DJC_PREFIX', 'djc')

--- a/djconfig/utils.py
+++ b/djconfig/utils.py
@@ -3,12 +3,6 @@
 from __future__ import unicode_literals
 from functools import wraps
 
-from .settings import PREFIX
-
-
-def prefixer(key):
-    return "%s:%s" % (PREFIX, key)
-
 
 def override_djconfig(**new_cache_values):
     """

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-djconfig',
-    version='0.3.2',
+    version='0.4.0',
     description='DjConfig is a Django app for storing other apps configurations.',
     author='Esteban Castro Borsani',
     author_email='ecastroborsani@gmail.com',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -16,7 +16,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'djconfig.middleware.DjConfigLocMemMiddleware'
+    'djconfig.middleware.DjConfigMiddleware'
 )
 
 
@@ -24,12 +24,5 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': 'db.sqlite3',
-    }
-}
-
-
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     }
 }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,8 +3,9 @@
 from __future__ import unicode_literals
 import datetime
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django import forms
+from django.conf import settings
 
 from djconfig import registry
 from djconfig import forms as djconfig_forms
@@ -47,6 +48,14 @@ class DjConfigTest(TestCase):
             """"""
 
         self.assertRaises(AssertionError, registry.register, BadForm)
+
+
+    @override_settings(MIDDLEWARE_CLASSES=settings.MIDDLEWARE_CLASSES[:-1])
+    def test_register_check_backend(self):
+        """
+        Raises valueError if middleware is missing
+        """
+        self.assertRaises(ValueError, registry.register, FooForm)
 
 
 class BarForm(ConfigForm):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,7 +12,7 @@ from djconfig.utils import override_djconfig
 from djconfig.conf import Config, config
 from djconfig.forms import ConfigForm
 from djconfig.models import Config as ConfigModel
-from djconfig.middleware import DjConfigLocMemMiddleware
+from djconfig.middleware import DjConfigMiddleware, DjConfigLocMemMiddleware
 
 
 class FooForm(ConfigForm):
@@ -345,7 +345,7 @@ class DjConfigMiddlewareTest(TestCase):
         cache = config._cache
 
         # Should not reload since _updated_at does not exists (form was not saved)
-        middleware = DjConfigLocMemMiddleware()
+        middleware = DjConfigMiddleware()
         middleware.process_request(request=None)
         self.assertIsNone(cache.get('char'))
 
@@ -366,6 +366,12 @@ class DjConfigMiddlewareTest(TestCase):
         middleware.process_request(request=None)
         self.assertEqual(cache.get('char'), "bar")
         self.assertEqual(cache.get("_updated_at"), "222")
+
+    def test_config_middleware_old(self):
+        """
+        Regression test for the old LocMem Middleware
+        """
+        self.assertEqual(DjConfigLocMemMiddleware, DjConfigMiddleware)
 
 
 class DjConfigUtilsTest(TestCase):


### PR DESCRIPTION
* No longer use django cache
* Renamed `DjConfigLocMemMiddleware` to `DjConfigMiddleware`
* `DjConfigMiddleware` is required