### PR TITLE
middleware compat

### DIFF
--- a/djconfig/middleware.py
+++ b/djconfig/middleware.py
@@ -4,10 +4,16 @@ from __future__ import unicode_literals
 
 from . import conf
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django < 1.10
+    MiddlewareMixin = object
+
+
 __all__ = ['DjConfigMiddleware', ]
 
 
-class DjConfigMiddleware(object):
+class DjConfigMiddleware(MiddlewareMixin):
     """
     Populate the cache using the database.\
     Reload the cache *only* if it is not up\

--- a/djconfig/utils.py
+++ b/djconfig/utils.py
@@ -38,6 +38,15 @@ def override_djconfig(**new_cache_values):
             conf.config._set_many(new_cache_values)
 
             try:
+                # todo: make a note about this in the docs: don't populate the config within migrations
+
+                # This works coz the config table is empty,
+                # so even if the middleware gets called,
+                # it won't update the config (_updated_at
+                # will be None), this is assuming the table
+                # is not populated by the user (ie: within
+                # a migration), in which case it will load
+                # all the default values
                 return func(*args, **kw)
             finally:
                 conf.config._set_many(old_cache_values)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -47,6 +47,8 @@ Configuration
         },
     ]
 
+.. note:: Use **MIDDLEWARE** instead of **MIDDLEWARE_CLASSES** in Django >= 1.10
+
 Afterwards, run::
 
     $ python manage.py migrate


### PR DESCRIPTION
Fixes #23 

* Adds compat `MiddlewareMixin` to `DjConfigMiddleware` on Django < 1.10